### PR TITLE
Adds config param to force https in Link headers

### DIFF
--- a/lib/api_pagination_headers.rb
+++ b/lib/api_pagination_headers.rb
@@ -19,6 +19,9 @@ module ApiPaginationHeaders
 
   def create_links(pages, scope)
     url_without_params = request.url.split('?').first
+    if ApiPaginationHeaders.config.force_https
+      url_without_params.sub! 'http://', 'https://'
+    end
 
     if params[:per_page]
       per_page = params[:per_page].to_i

--- a/lib/api_pagination_headers/config.rb
+++ b/lib/api_pagination_headers/config.rb
@@ -20,5 +20,6 @@ module ApiPaginationHeaders
     TOTAL_COUNT_HEADER = 'Total-Count'
 
     config_accessor(:total_count_header)  { TOTAL_COUNT_HEADER }
+    config_accessor(:force_https)  { false }
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -98,4 +98,16 @@ describe PostsController, '#index', type: :controller do
       expect(response.headers['Link']).to eq("<#{posts_url(page: 2, per_page: 1, order: 'asc', format: :json)}>; rel=\"next\", <#{posts_url(page: 2, per_page: 1, order: 'asc', format: :json)}>; rel=\"last\"")
     end
   end
+
+  context 'when config has force_https set to true' do
+    it 'replaces http:// with https:// in Link header' do
+      ApiPaginationHeaders.config.force_https = true
+      FactoryGirl.create_list(:post, 2)
+      get :index, order: 'asc', format: :json
+      expect(response.headers['Link']).to match 'https://'
+      expect(response.headers['Link']).not_to match 'http://'
+      ApiPaginationHeaders.config.force_https = false
+    end
+  end
+
 end


### PR DESCRIPTION
Added an optional config parameter to force http in Link headers.

Use Case:
Client->load-balancer is an SSL configuration but internally the load-balancer->app-server is not SSL.

Externally we always use SSL but after the load balancer gets the request it converts it to non-ssl so theres less chatter and latency caused by SSL internally from the load balancer to the app server.
